### PR TITLE
add -p (poweroff) to halt command

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -120,6 +120,6 @@ void MainWindow::reject() { QApplication::quit(); }
 
 void MainWindow::on_pushRestart() { QProcess::startDetached("sudo", {"-n", "reboot"}); }
 
-void MainWindow::on_pushShutdown() { QProcess::startDetached("sudo", {"-n", "/sbin/halt --poweroff"}); }
+void MainWindow::on_pushShutdown() { QProcess::startDetached("sudo", {"-n", "/sbin/halt -p"}); }
 
 bool MainWindow::isRaspberryPi() { return QProcess::execute("test", {"-f", "/etc/rpi-issue"}) == 0; }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -120,6 +120,6 @@ void MainWindow::reject() { QApplication::quit(); }
 
 void MainWindow::on_pushRestart() { QProcess::startDetached("sudo", {"-n", "reboot"}); }
 
-void MainWindow::on_pushShutdown() { QProcess::startDetached("sudo", {"-n", "/sbin/halt"}); }
+void MainWindow::on_pushShutdown() { QProcess::startDetached("sudo", {"-n", "/sbin/halt --poweroff"}); }
 
 bool MainWindow::isRaspberryPi() { return QProcess::execute("test", {"-f", "/etc/rpi-issue"}) == 0; }


### PR DESCRIPTION
under systemd while running live regular "halt" does not power down the PC, likely because of a issue with the live system not being quite compatible with systemd.